### PR TITLE
Implement delete table functionality: Create endpoint and frontend view

### DIFF
--- a/backend/todo-api/src/tables/controllers/tables.controller.ts
+++ b/backend/todo-api/src/tables/controllers/tables.controller.ts
@@ -7,6 +7,7 @@ import {
 	HttpStatus,
 	UseGuards,
 	Request,
+	Param,
 	Res,
 } from '@nestjs/common';
 import * as mongoose from "mongoose"
@@ -46,10 +47,29 @@ export class TablesController {
 		return userTables;
 	}
 
-	 //delete set - to do in the future (happens when user deletes his account)
-	// @Get('/logout')
-	// 	logout(@Request() req): any {
-	// 		req.session.destroy();
-	// 		return { msg: 'The user session has ended' }
-	// 	}
+	//delete table
+	@UseGuards(AuthenticatedGuard)
+	@Post('/delete/:id')
+	async deleteTable(
+		@Param('id') id: string,
+		@Request() req,
+		@Res() res,
+	) {
+		const userId: mongoose.Types.ObjectId = req.user.id
+		const result = await this.tablesService.deleteTable(
+      id,
+			userId.toString(),
+			);
+
+		if (result) {
+			return res.status(HttpStatus.OK).json({
+				message: 'Table deleted successfully',
+				data: result,
+			});
+		} else {
+			return res.status(HttpStatus.NOT_FOUND).json({
+				message: 'Table not found',
+			});
+		}
+	}
 }

--- a/frontend/todo_app/src/App.tsx
+++ b/frontend/todo_app/src/App.tsx
@@ -15,6 +15,7 @@ import Auth from './components/Auth';
 import Column from './components/Column';
 import Set from './components/Set';
 import { table } from 'console';
+import DeleteTable from './components/DeleteTable';
 
 type ColumnData = {
   _id: string,
@@ -93,13 +94,15 @@ const App: React.FC = () => {
                         </div>
                       </div>
                         <div className='col-span-1 flex justify-center items-center'>
-                          <img className='h-1/2' src={process.env.PUBLIC_URL + '/icon-trash.svg'} alt="Trash Icon"></img>
+                          <DeleteTable currentTable={currentTable} setRerenderSignal={setRerenderSignal} tables={tables} setCurrentTable={setCurrentTable} setColumns={setColumns}></DeleteTable>
                         </div>
                     </div>
                   </div>
-                  <div className="flex flex-nowrap overflow-x-auto max-w-full">
-                    <Column columns={columns} setColumns={setColumns} setRerenderSignal={setRerenderSignal} currentTable={currentTable}/>
-                  </div>
+                  {currentTable &&
+                    <div className="flex flex-nowrap overflow-x-auto max-w-full">
+                      <Column columns={columns} setColumns={setColumns} setRerenderSignal={setRerenderSignal} currentTable={currentTable}/>
+                    </div>
+                  }
                 </div>
               </div>
           </Auth>

--- a/frontend/todo_app/src/components/DeleteTable.tsx
+++ b/frontend/todo_app/src/components/DeleteTable.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from "react";
+import axios, { AxiosError } from "axios";
+import { table } from "console";
+
+interface Task {
+  _id: string,
+  title: string,
+  completed: boolean;
+}
+
+interface User {
+	_id: string;
+	__v: number;
+}
+
+interface Column {
+  _id: string,
+  title: string,
+  tasks: Task[];
+  showCompletedTasks: boolean;
+}
+
+interface TableProps {
+	columns: Column[];
+	title: string;
+	users: User[];
+	__v: number;
+	_id: string;
+}
+
+type DeleteTableProps = {
+	currentTable: string;
+	setRerenderSignal: React.Dispatch<React.SetStateAction<boolean>>;
+  tables: TableProps[];
+	setCurrentTable: React.Dispatch<string>;
+	setColumns: React.Dispatch<React.SetStateAction<Column[]>>
+};
+
+const DeleteTable: React.FC<DeleteTableProps> = ({ currentTable, setRerenderSignal, tables, setCurrentTable, setColumns }) => {
+	const [deleteModalMessage, setDeleteModalMessage] = useState('')
+	const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+	const [deleteModalAction, setDeleteModalAction] = useState(false);
+
+	const handleDeleteModalAction = (e: React.MouseEvent<HTMLElement>) => {
+		e.preventDefault()
+		if (deleteModalAction) {
+			// Perform the action and update the current table and rerender
+			setRerenderSignal(prevSignal => !prevSignal);
+			if (currentTable !== tables[0]._id) {
+				setCurrentTable(tables[0]._id)
+			} else {
+				setCurrentTable(tables.length > 1 ? tables[1]._id : '');
+			}
+		}
+	
+		// Close the modal and reset the action state
+		setIsDeleteModalOpen(false);
+		setDeleteModalAction(false);
+	};
+
+	const performDelete = async () => {
+		const tableId = currentTable;
+		console.log(tableId)
+
+		if(!currentTable) {
+			return;
+		}
+
+		try {
+				const response = await axios.post(`http://localhost:5000/tables/delete/${tableId}`, {},
+				{
+					withCredentials: true,
+					headers: {
+						'Access-Control-Allow-Origin': '*',
+						'Content-Type': 'application/json'
+					}
+				})
+
+			if (response.status === 200) {
+				setDeleteModalMessage('Table deleted succesfully')
+				setIsDeleteModalOpen(true)
+				setDeleteModalAction(true);
+			}
+		} catch (err: any) {
+			if (err.response && err.response.status === 404) {
+				setDeleteModalMessage('Table not found');
+				setIsDeleteModalOpen(true);
+				setDeleteModalAction(false);
+			} else {
+				setDeleteModalMessage(`Something went wrong, try again`);
+				setIsDeleteModalOpen(true);
+				setDeleteModalAction(false);
+			}
+	}
+	}
+	return (
+		<>
+			<img className='h-1/2 cursor-pointer' 
+				src={process.env.PUBLIC_URL + '/icon-trash.svg'}
+				alt="Trash Icon"
+				onClick={performDelete}
+			></img>
+			{isDeleteModalOpen && 
+				<div className="w-screen h-screen bg-black bg-opacity-30 absolute top-0 left-0 flex justify-center items-center">
+					<div className="bg-white rounded-md">
+						<div className="p-6 text-center">
+							<p>
+								{deleteModalMessage}
+							</p>
+							<button
+							onClick={(e)=>handleDeleteModalAction(e)}
+							className="bg-purple-400 p-2 pl-6 pr-6 rounded-md mt-4"
+							>OK</button>
+						</div>
+					</div>
+				</div>
+			}
+		</>
+	);
+};
+
+export default DeleteTable;


### PR DESCRIPTION
I have created a delete table endpoint that deletes the specified table, along with all columns and tasks within that table. The deletion is based on the given ID received from the URL parameters.

The delete table view sends a delete request to the server, using the ID of the currently chosen table. The view then updates the relevant states based on the response from the server. After successfully deleting the table, the user will see the first accessible table within their table set. If there are no more tables remaining, an empty view is displayed.