### PR TITLE
Implement table members permissions feature

### DIFF
--- a/backend/todo-api/src/invitations/invitations.controller.ts
+++ b/backend/todo-api/src/invitations/invitations.controller.ts
@@ -2,6 +2,8 @@ import {
   Body,
   Controller,
   Get,
+  HttpException,
+  HttpStatus,
   Post,
   Param,
   UseGuards,
@@ -24,17 +26,21 @@ export class InvitationsController {
     @Body('tableId') tableId: string,
     @Body('tableName') tableName: string,
   ) {
-    const result = await this.invitationsService.inviteUser(
-      inviteeEmail,
-      inviterId,
-      tableId,
-      tableName,
-    );
+    try {
+      const result = await this.invitationsService.inviteUser(
+        inviteeEmail,
+        inviterId,
+        tableId,
+        tableName,
+      );
 
-    return {
-      result,
-      msg: 'User invited successfully.',
-    };
+      return {
+        result,
+        msg: 'User invited successfully.',
+      };
+    } catch (error) {
+      throw new HttpException(error.message, HttpStatus.BAD_REQUEST);
+    }
   }
 
   //Accept invitation

--- a/backend/todo-api/src/tables/controllers/tables.controller.ts
+++ b/backend/todo-api/src/tables/controllers/tables.controller.ts
@@ -9,6 +9,7 @@ import {
   Request,
   Param,
   Res,
+  Req,
 } from '@nestjs/common';
 import * as mongoose from 'mongoose';
 import { AuthenticatedGuard } from 'src/auth/authenticated.guard';
@@ -128,6 +129,7 @@ export class TablesController {
     }
   }
 
+  @UseGuards(AuthenticatedGuard)
   @Post('/users')
   async insertUser(
     @Body('userId') userId: string,
@@ -148,6 +150,36 @@ export class TablesController {
     }
   }
 
+  //update permissions
+  @UseGuards(AuthenticatedGuard)
+  @Post('/:id/permissions')
+  async changeMemberPermission(
+    @Param('id') tableId: string,
+    @Body('userId') userId: string,
+    @Body('newPermission') newPermission: string,
+    @Req() req,
+    @Res() res,
+  ) {
+    const updaterId = req.user.id;
+    try {
+      const result = await this.tablesService.changeMemberPermission(
+        tableId,
+        userId,
+        updaterId,
+        newPermission,
+      );
+      return res.status(HttpStatus.OK).json({
+        message: 'Permissions changed successfully',
+        data: result,
+      });
+    } catch (error) {
+      return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+        message: 'Failed to change permissions',
+        error: error.message,
+      });
+    }
+  }
+
   //testing tables
   @Get('/alltables')
   async getAllTables(@Res() res) {
@@ -159,8 +191,8 @@ export class TablesController {
       });
     } catch (error) {
       return res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
-        message: 'Failed to retrieve tables',
-        error: error.message,
+        message: 'Failed to change permissions',
+        error: error.message || 'An error occurred',
       });
     }
   }

--- a/backend/todo-api/src/tables/services/tables.service.ts
+++ b/backend/todo-api/src/tables/services/tables.service.ts
@@ -20,7 +20,7 @@ export class TablesService {
       const newTable = new this.tableModel({
         title: title,
         columns: [],
-        users: [user],
+        users: [{ user: user, permission: 'admin' }],
       });
       await newTable.save();
       return newTable;
@@ -31,7 +31,7 @@ export class TablesService {
 
   async getUserTables(requestUser: mongoose.Types.ObjectId): Promise<Table[]> {
     const userTable = await this.tableModel
-      .find({ users: requestUser })
+      .find({ 'users.user': requestUser })
       .populate({
         path: 'columns',
         populate: [
@@ -48,7 +48,7 @@ export class TablesService {
     try {
       const table = await this.tableModel.findByIdAndUpdate(
         tableId,
-        { $pull: { users: memberId } },
+        { $pull: { users: { user: memberId } } },
         { new: true },
       );
 
@@ -71,7 +71,6 @@ export class TablesService {
     const table = await this.tableModel.findOneAndUpdate(
       {
         _id: tableId,
-        users: userId,
       },
       {
         title: newTitle,
@@ -88,7 +87,6 @@ export class TablesService {
   async deleteTable(tableId: string, userId: string): Promise<boolean> {
     const table = await this.tableModel.findOne({
       _id: tableId,
-      users: userId,
     });
 
     // Return false if no table with given id or user is unauthorized
@@ -123,7 +121,7 @@ export class TablesService {
     try {
       const table = await this.tableModel.findByIdAndUpdate(
         tableId,
-        { $addToSet: { users: userId } },
+        { $addToSet: { users: { user: userId, permission: 'none' } } },
         { new: true },
       );
 
@@ -142,13 +140,63 @@ export class TablesService {
     const userMembers = await this.tableModel
       .findOne({ _id: tableId })
       .populate({
-        path: 'users',
+        path: 'users.user',
         model: 'user',
-        select: '-password', // Exclude the 'password' field
+        select: '-password -id', // Exclude the 'password' field
       })
       .select('users')
       .exec();
     return userMembers?.users; // Return only the 'users' field
+  }
+
+  async changeMemberPermission(
+    tableId: string,
+    userId: string,
+    updaterId: string,
+    newPermission: string,
+  ): Promise<any> {
+    try {
+      const table = await this.tableModel.findById(tableId);
+
+      if (!table) {
+        throw new Error('Table not found');
+      }
+
+      // Check if the user's who's updating permission is "admin" or "invite"
+      const updaterPermission = table.users.find(
+        (user) => user.user.toString() === updaterId,
+      );
+
+      if (!updaterPermission) {
+        throw new Error('Permission not found');
+      }
+
+      if (updaterPermission.permission !== 'admin') {
+        throw new Error('Inviter does not have sufficient permission');
+      }
+
+      // Find the index of the user in the users array
+      const memberIndex = table.users.findIndex((user) => {
+        return user.user._id.toString() === userId;
+      });
+
+      if (memberIndex !== -1) {
+        // Update the user's permission
+        table.users[memberIndex].permission = newPermission as
+          | 'none'
+          | 'admin'
+          | 'invite';
+
+        // Save the updated table
+        await table.save();
+
+        return `User ${userId} permission updated to ${newPermission}`;
+      } else {
+        throw new Error('User not found in the table');
+      }
+    } catch (err) {
+      throw { message: err.message };
+    }
   }
 
   //Helper function for deleting table with its items

--- a/backend/todo-api/src/tables/tables.model.ts
+++ b/backend/todo-api/src/tables/tables.model.ts
@@ -14,8 +14,15 @@ export const TableSchema = new mongoose.Schema({
   ],
   users: [
     {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: 'User',
+      user: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User',
+      },
+      permission: {
+        type: String,
+        enum: ['admin', 'invite', 'none'],
+        default: 'none',
+      },
     },
   ],
 });
@@ -65,7 +72,10 @@ export interface Table extends Document {
   _id: string;
   title: string;
   columns: mongoose.Types.DocumentArray<Column>;
-  users: mongoose.Types.Array<User['_id']>;
+  users: Array<{
+    user: mongoose.Types.ObjectId;
+    permission: 'admin' | 'invite' | 'none';
+  }>;
 }
 
 export interface Column extends Document {

--- a/frontend/todo_app/src/components/EditTable.tsx
+++ b/frontend/todo_app/src/components/EditTable.tsx
@@ -6,6 +6,7 @@ import { Input } from "@material-tailwind/react";
 import DeleteTable from "./DeleteTable";
 import InviteUser from "./InviteUser";
 import TablePermissions from "./TablePermissions";
+import MembersPagination from "./MembersPagination";
 
 interface Task {
   _id: string;
@@ -61,6 +62,8 @@ const EditTable: React.FC<EditTableProps> = ({
   const [EditTableModalMessage, setEditTableModalMessage] = useState("");
   const [prevTableName, setPrevTableName] = useState(table.title);
   const [tableName, setTableName] = useState(table.title);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [canInvite, setCanInvite] = useState(false);
 
   const [tableMembers, setTableMembers] = useState<string[]>([]);
 
@@ -146,16 +149,18 @@ const EditTable: React.FC<EditTableProps> = ({
               onClick={(event) => event.stopPropagation()}
             >
               <div className="">
-                <div className="flex justify-end">
-                  <DeleteTable
-                    tableId={table._id}
-                    tableTitle={table.title}
-                    setRerenderSignal={setRerenderSignal}
-                    tables={tables}
-                    setCurrentTable={setCurrentTable}
-                    setColumns={setColumns}
-                  ></DeleteTable>
-                </div>
+                {isAdmin && (
+                  <div className="flex justify-end">
+                    <DeleteTable
+                      tableId={table._id}
+                      tableTitle={table.title}
+                      setRerenderSignal={setRerenderSignal}
+                      tables={tables}
+                      setCurrentTable={setCurrentTable}
+                      setColumns={setColumns}
+                    ></DeleteTable>
+                  </div>
+                )}
                 <div className="relative flex w-full max-w-[24rem]">
                   <Input
                     color="deep-purple"
@@ -173,14 +178,20 @@ const EditTable: React.FC<EditTableProps> = ({
                   ></Input>
                 </div>
               </div>
-              <InviteUser
-                tableMembers={tableMembers}
-                user={user}
-                tableId={table._id}
-                tableName={table.title}
-              ></InviteUser>
+              {(isAdmin || canInvite) && (
+                <InviteUser
+                  tableMembers={tableMembers}
+                  user={user}
+                  tableId={table._id}
+                  tableName={table.title}
+                ></InviteUser>
+              )}
               <TablePermissions
                 user={user}
+                isAdmin={isAdmin}
+                setIsAdmin={setIsAdmin}
+                canInvite={canInvite}
+                setCanInvite={setCanInvite}
                 tableId={table._id}
                 tableName={table.title}
                 tableUsersIds={table.users}

--- a/frontend/todo_app/src/components/InviteUser.tsx
+++ b/frontend/todo_app/src/components/InviteUser.tsx
@@ -81,7 +81,13 @@ const InviteUser: React.FC<UserProps> = ({
     } catch (err: any) {
       setInviteResponseStatusOK(false);
       setIsInviteResponseVisible(true);
-      setResponseMessage("User not found");
+      if (err.response.data.message.includes("permission")) {
+        setResponseMessage(
+          "You have no permission to invite. Refresh the page."
+        );
+      } else {
+        setResponseMessage("User not found");
+      }
     }
   };
 

--- a/frontend/todo_app/src/components/MembersPagination.tsx
+++ b/frontend/todo_app/src/components/MembersPagination.tsx
@@ -10,13 +10,18 @@ interface User {
   userIconId: number;
 }
 
+interface Member {
+  user: User;
+  permission: string;
+}
+
 interface MembersPaginationProps {
   totalPages: number;
   setTotalPages: React.Dispatch<React.SetStateAction<number>>;
   currentPage: number;
   pageSize: number;
   setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
-  members: User[];
+  members: Member[];
   setMembersRerenderSignal: React.Dispatch<React.SetStateAction<boolean>>;
 }
 

--- a/frontend/todo_app/src/components/RemoveMember.tsx
+++ b/frontend/todo_app/src/components/RemoveMember.tsx
@@ -2,10 +2,29 @@ import React, { useState } from "react";
 import axios from "axios";
 import { Button } from "@material-tailwind/react";
 
+interface User {
+  _id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  level?: string;
+  userIconId: number;
+}
+
+interface Member {
+  user: User;
+  permission: string;
+}
+
 type RemoveMemberProps = {
+  user: User;
+  currentUser: User;
+  members: Member[];
   memberId: string;
   memberName: string;
   memberEmail: string;
+  memberPermission: string;
+  isAdmin: Boolean;
   tableId: string;
   tableName: string;
   membersRerenderSignal: boolean;
@@ -13,17 +32,34 @@ type RemoveMemberProps = {
 };
 
 const RemoveMember: React.FC<RemoveMemberProps> = ({
+  user,
+  currentUser,
+  members,
   memberId,
   memberName,
   memberEmail,
+  memberPermission,
+  isAdmin,
   tableId,
   tableName,
   membersRerenderSignal,
   setMembersRerenderSignal,
 }) => {
   const [isRemoveMemberModalOpen, setIsRemoveMemberModalOpen] = useState(false);
+  const [isRemovePossible, setIsRemovePossible] = useState(true);
 
   const openRemoveMemberModalOpen = () => {
+    // Check if this is the last admin of the table - last admin before leaving the table
+    // has to nominate new admin before leaving
+    if (
+      isAdmin &&
+      memberPermission === "admin" &&
+      members.filter((member) => member.permission === "admin").length === 1
+    ) {
+      setIsRemovePossible(false);
+    } else {
+      setIsRemovePossible(true);
+    }
     setIsRemoveMemberModalOpen(true);
   };
 
@@ -77,30 +113,58 @@ const RemoveMember: React.FC<RemoveMemberProps> = ({
             className="bg-white p-6 rounded-md"
             onClick={(event) => event.stopPropagation()}
           >
-            <p className="font-400">
-              Do you want to remove&nbsp;
-              <span className="font-700">
-                {memberName.length > 1 ? memberName : memberEmail}
-              </span>
-              &nbsp;from table&nbsp;
-              <span className="font-700">{tableName}</span>?
-            </p>
-            <div className="flex justify-center">
-              <div className="grid grid-cols-2 mt-2 gap-8 w-64">
-                <Button
-                  className="bg-purple-900 shadow-gray-400 hover:shadow-gray-400 p-2 pl-6 pr-6 rounded-md mt-4"
-                  onClick={(e) => removeMember(e)}
-                >
-                  Yes
-                </Button>
-                <Button
-                  className="bg-purple-900 shadow-gray-400 hover:shadow-gray-400 p-2 pl-6 pr-6 rounded-md mt-4"
-                  onClick={closeRemoveMemberModal}
-                >
-                  No
-                </Button>
+            {isRemovePossible ? (
+              <div>
+                <p className="font-400">
+                  {currentUser._id === memberId ? (
+                    <>
+                      Do you want to leave table&nbsp;
+                      <span className="font-700">{tableName}</span>?
+                    </>
+                  ) : (
+                    <>
+                      Do you want to remove&nbsp;
+                      <span className="font-700">
+                        {memberName.length > 1 ? memberName : memberEmail}
+                      </span>
+                      &nbsp;from table&nbsp;
+                      <span className="font-700">{tableName}</span>?
+                    </>
+                  )}
+                </p>
+                <div className="flex justify-center">
+                  <div className="grid grid-cols-2 mt-2 gap-8 w-64">
+                    <Button
+                      className="bg-purple-900 shadow-gray-400 hover:shadow-gray-400 p-2 pl-6 pr-6 rounded-md mt-4"
+                      onClick={(e) => removeMember(e)}
+                    >
+                      Yes
+                    </Button>
+                    <Button
+                      className="bg-purple-900 shadow-gray-400 hover:shadow-gray-400 p-2 pl-6 pr-6 rounded-md mt-4"
+                      onClick={closeRemoveMemberModal}
+                    >
+                      No
+                    </Button>
+                  </div>
+                </div>
               </div>
-            </div>
+            ) : (
+              <div>
+                <p className="font-400">
+                  The only admin has to nominate new admin before leaving the
+                  table.
+                </p>
+                <div className="flex justify-center">
+                  <Button
+                    className="bg-purple-900 shadow-gray-400 hover:shadow-gray-400 p-2 pl-6 pr-6 rounded-md mt-4"
+                    onClick={closeRemoveMemberModal}
+                  >
+                    OK
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
I have implemented a members permission feature that allows users in the EditTable view within TablePermissions to modify permissions. There are three roles available: admin - can both invite and remove members, invite - can only invite members, none - has no permissions. Additionally, I have added a guard clause to prevent the only admin in the table from leaving or removing their admin role until they nominate a new admin. I have also replaced the checkbox-based permission assignment with a simple select list.