### PR TITLE
Implement optimistic task-column-ui

### DIFF
--- a/backend/todo-api/src/tables/controllers/columns.controller.ts
+++ b/backend/todo-api/src/tables/controllers/columns.controller.ts
@@ -77,8 +77,15 @@ export class ColumnsController {
   //toggle show completed tasks
   @UseGuards(AuthenticatedGuard)
   @Post('/:id/status')
-  async toggleCompletedTaskStatus(@Param('id') id: string, @Res() res) {
-    const result = await this.columnsService.toggleCompletedTaskStatus(id);
+  async toggleCompletedTaskStatus(
+    @Param('id') id: string,
+    @Body('showCompletedTasks') showCompletedTasks: boolean,
+    @Res() res,
+  ) {
+    const result = await this.columnsService.toggleCompletedTaskStatus(
+      id,
+      showCompletedTasks,
+    );
 
     if (result) {
       return res.status(HttpStatus.OK).json({
@@ -108,7 +115,6 @@ export class ColumnsController {
     const result = await this.columnsService.moveTaskWithinColumn(
       id,
       movedTaskId,
-      sourceColumn,
       destinationColumnId,
       destinationIndex,
       completed,

--- a/backend/todo-api/src/tables/controllers/tasks.controller.ts
+++ b/backend/todo-api/src/tables/controllers/tasks.controller.ts
@@ -76,8 +76,17 @@ export class TasksController {
 
   @UseGuards(AuthenticatedGuard)
   @Post('/:id/status')
-  async toggleTaskStatus(@Param('id') id: string, @Res() res) {
-    const result = await this.tasksService.toggleTaskStatus(id);
+  async toggleTaskStatus(
+    @Param('id') id: string,
+    @Body('taskCompleted') taskCompleted: boolean,
+    @Body('taskColumn') taskColumn: string,
+    @Res() res,
+  ) {
+    const result = await this.tasksService.toggleTaskStatus(
+      id,
+      taskCompleted,
+      taskColumn,
+    );
 
     if (result) {
       return res.status(HttpStatus.OK).json({

--- a/frontend/todo_app/src/components/AddTask.tsx
+++ b/frontend/todo_app/src/components/AddTask.tsx
@@ -3,7 +3,6 @@ import axios from "axios";
 
 interface AddTaskProps {
   columnId: string;
-  addTask: (columnId: string) => void;
   setRerenderSignal: React.Dispatch<React.SetStateAction<boolean>>;
 }
 

--- a/frontend/todo_app/src/components/AuthenticatedRoutes.tsx
+++ b/frontend/todo_app/src/components/AuthenticatedRoutes.tsx
@@ -25,6 +25,7 @@ type Task = {
   _id: string;
   title: string;
   completed: boolean;
+  column: string;
 };
 
 interface User {

--- a/frontend/todo_app/src/components/DeleteTable.tsx
+++ b/frontend/todo_app/src/components/DeleteTable.tsx
@@ -7,6 +7,7 @@ interface Task {
   _id: string;
   title: string;
   completed: boolean;
+  column: string;
 }
 
 interface User {

--- a/frontend/todo_app/src/components/EditTable.tsx
+++ b/frontend/todo_app/src/components/EditTable.tsx
@@ -12,6 +12,7 @@ interface Task {
   _id: string;
   title: string;
   completed: boolean;
+  column: string;
 }
 
 interface User {

--- a/frontend/todo_app/src/components/InviteUser.tsx
+++ b/frontend/todo_app/src/components/InviteUser.tsx
@@ -86,7 +86,7 @@ const InviteUser: React.FC<UserProps> = ({
           "You have no permission to invite. Refresh the page."
         );
       } else {
-        setResponseMessage("User not found");
+        setResponseMessage(err.response.data.message);
       }
     }
   };

--- a/frontend/todo_app/src/components/Set.tsx
+++ b/frontend/todo_app/src/components/Set.tsx
@@ -12,6 +12,7 @@ interface Task {
   _id: string;
   title: string;
   completed: boolean;
+  column: string;
 }
 
 interface User {

--- a/frontend/todo_app/src/components/Task.tsx
+++ b/frontend/todo_app/src/components/Task.tsx
@@ -7,6 +7,7 @@ interface TaskData {
   _id: string;
   title: string;
   completed: boolean;
+  column: string;
 }
 
 interface TaskProps {
@@ -22,11 +23,17 @@ const Task: React.FC<TaskProps> = ({ task, taskIndex, setRerenderSignal }) => {
     setIsEditTaskModalOpen(true);
   };
 
-  const toggleTaskStatus = async (taskId: string, taskIndex: Number) => {
+  const toggleTaskStatus = async (
+    taskId: string,
+    taskIndex: Number,
+    taskCompleted: boolean,
+    taskColumn: string
+  ) => {
+    console.log(taskColumn);
     try {
       const response = await axios.post(
         `http://localhost:5000/tasks/${taskId}/status`,
-        {},
+        { taskCompleted: taskCompleted, taskColumn: taskColumn },
         {
           withCredentials: true,
           headers: {
@@ -57,7 +64,7 @@ const Task: React.FC<TaskProps> = ({ task, taskIndex, setRerenderSignal }) => {
           className="w-6 max-h-6"
           onClick={(event) => {
             event.stopPropagation();
-            toggleTaskStatus(task._id, taskIndex);
+            toggleTaskStatus(task._id, taskIndex, task.completed, task.column);
           }}
         />
         <div className="ml-2 min-w-1">{task.title}</div>


### PR DESCRIPTION
This commit introduces optimistic UI updates for tasks and columns. Now, when a user moves a task, they see immediate changes reflected on the frontend. The backend update request is sent afterwards to synchronize the changes. These changes enhance the drag and drop feature, allowing users to freely move tasks while ensuring the backend handles situations where the task's actual position differs from the user's frontend view.

Additionally, a bug was fixed where resending a pending invitation resulted in an error message stating 'User not found'. Now, users are properly informed that the same invitation already exists.