### PR TITLE
Implement task-details

### DIFF
--- a/backend/todo-api/src/tables/controllers/tasks.controller.ts
+++ b/backend/todo-api/src/tables/controllers/tasks.controller.ts
@@ -99,4 +99,26 @@ export class TasksController {
       });
     }
   }
+
+  @UseGuards(AuthenticatedGuard)
+  @Post('/:id/notes')
+  async updateNotes(
+    @Param('id') id: string,
+    @Body('newNotes') newNotes: string,
+    @Res() res,
+  ) {
+    try {
+      const result = await this.tasksService.updateNotes(id, newNotes);
+
+      return res.status(HttpStatus.OK).json({
+        message: 'Task notes updated successfully',
+        data: result,
+      });
+    } catch (error) {
+      return res.status(HttpStatus.NOT_FOUND).json({
+        message: 'Task not found',
+        error: error.message,
+      });
+    }
+  }
 }

--- a/backend/todo-api/src/tables/services/tasks.service.ts
+++ b/backend/todo-api/src/tables/services/tasks.service.ts
@@ -206,4 +206,29 @@ export class TasksService {
     !isTheSameColumn && (await destinationColumn.save());
     return true;
   }
+
+  async updateNotes(taskId: string, newNotes: string): Promise<boolean> {
+    // Check if the length exceeds the maximum allowed
+    const maxLength = 500;
+    if (newNotes.length > maxLength) {
+      throw new Error(
+        `Notes length exceeds the maximum allowed (${maxLength} characters).`,
+      );
+    }
+
+    const task = await this.taskModel.findOneAndUpdate(
+      {
+        _id: taskId,
+      },
+      {
+        notes: newNotes,
+      },
+      { new: true },
+    );
+
+    if (!task) {
+      throw new Error('Task not found');
+    }
+    return true;
+  }
 }

--- a/backend/todo-api/src/tables/tables.model.ts
+++ b/backend/todo-api/src/tables/tables.model.ts
@@ -51,22 +51,32 @@ export const ColumnSchema = new mongoose.Schema({
   },
 });
 
-export const TaskSchema = new mongoose.Schema({
-  title: {
-    type: String,
-    required: true,
+export const TaskSchema = new mongoose.Schema(
+  {
+    title: {
+      type: String,
+      required: true,
+    },
+    notes: {
+      type: String,
+      required: false,
+      default: '',
+    },
+    completed: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
+    column: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Column',
+      required: true,
+    },
   },
-  completed: {
-    type: Boolean,
-    required: true,
-    default: false,
+  {
+    timestamps: true,
   },
-  column: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: 'Column',
-    required: true,
-  },
-});
+);
 
 export interface Table extends Document {
   _id: string;
@@ -87,6 +97,7 @@ export interface Column extends Document {
 
 export interface Task extends Document {
   title: string;
+  notes: string;
   completed: boolean;
   column: mongoose.Types.ObjectId;
 }

--- a/frontend/todo_app/src/components/AuthenticatedRoutes.tsx
+++ b/frontend/todo_app/src/components/AuthenticatedRoutes.tsx
@@ -16,16 +16,19 @@ import UserInvitations from "./UserInvitations";
 type ColumnData = {
   _id: string;
   title: string;
-  pendingTasks: Task[];
-  completedTasks: Task[];
+  pendingTasks: TaskData[];
+  completedTasks: TaskData[];
   showCompletedTasks: boolean;
 };
 
-type Task = {
+type TaskData = {
   _id: string;
   title: string;
   completed: boolean;
   column: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
 };
 
 interface User {

--- a/frontend/todo_app/src/components/Column.tsx
+++ b/frontend/todo_app/src/components/Column.tsx
@@ -31,6 +31,9 @@ interface TaskData {
   title: string;
   completed: boolean;
   column: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 const Column: React.FC<ColumnProps> = ({
@@ -39,6 +42,8 @@ const Column: React.FC<ColumnProps> = ({
   setRerenderSignal,
   currentTable,
 }) => {
+  const [isDraggingPossible, setIsDraggingPossible] = useState(true);
+
   const toggleShowCompletedTasks = async (
     columnId: string,
     showCompletedTasks: boolean
@@ -274,6 +279,7 @@ const Column: React.FC<ColumnProps> = ({
                         key={task._id}
                         draggableId={task._id}
                         index={index}
+                        isDragDisabled={!isDraggingPossible}
                       >
                         {(provided, snapshot) => (
                           <div
@@ -289,6 +295,8 @@ const Column: React.FC<ColumnProps> = ({
                               taskIndex={index}
                               task={task}
                               setRerenderSignal={setRerenderSignal}
+                              isDraggingPossible={isDraggingPossible}
+                              setIsDraggingPossible={setIsDraggingPossible}
                             />
                           </div>
                         )}
@@ -335,6 +343,7 @@ const Column: React.FC<ColumnProps> = ({
                             key={task._id}
                             draggableId={task._id}
                             index={index}
+                            isDragDisabled={!isDraggingPossible}
                           >
                             {(provided, snapshot) => (
                               <div
@@ -350,6 +359,8 @@ const Column: React.FC<ColumnProps> = ({
                                   taskIndex={index}
                                   task={task}
                                   setRerenderSignal={setRerenderSignal}
+                                  isDraggingPossible={isDraggingPossible}
+                                  setIsDraggingPossible={setIsDraggingPossible}
                                 />
                               </div>
                             )}

--- a/frontend/todo_app/src/components/DeleteTable.tsx
+++ b/frontend/todo_app/src/components/DeleteTable.tsx
@@ -3,11 +3,14 @@ import axios, { AxiosError } from "axios";
 
 import { Button } from "@material-tailwind/react";
 
-interface Task {
+interface TaskData {
   _id: string;
   title: string;
   completed: boolean;
   column: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface User {
@@ -22,8 +25,8 @@ interface User {
 interface Column {
   _id: string;
   title: string;
-  pendingTasks: Task[];
-  completedTasks: Task[];
+  pendingTasks: TaskData[];
+  completedTasks: TaskData[];
   showCompletedTasks: boolean;
 }
 

--- a/frontend/todo_app/src/components/EditTable.tsx
+++ b/frontend/todo_app/src/components/EditTable.tsx
@@ -8,11 +8,14 @@ import InviteUser from "./InviteUser";
 import TablePermissions from "./TablePermissions";
 import MembersPagination from "./MembersPagination";
 
-interface Task {
+interface TaskData {
   _id: string;
   title: string;
   completed: boolean;
   column: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface User {
@@ -27,8 +30,8 @@ interface User {
 interface Column {
   _id: string;
   title: string;
-  pendingTasks: Task[];
-  completedTasks: Task[];
+  pendingTasks: TaskData[];
+  completedTasks: TaskData[];
   showCompletedTasks: boolean;
 }
 

--- a/frontend/todo_app/src/components/EditTask.tsx
+++ b/frontend/todo_app/src/components/EditTask.tsx
@@ -5,6 +5,10 @@ interface TaskData {
   _id: string;
   title: string;
   completed: boolean;
+  column: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface ColumnData {
@@ -19,6 +23,7 @@ interface EditTaskProps {
   isEditTaskModalOpen: boolean;
   setIsEditTaskModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setRerenderSignal: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsDraggingPossible: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const EditTask: React.FC<EditTaskProps> = ({
@@ -26,12 +31,34 @@ const EditTask: React.FC<EditTaskProps> = ({
   isEditTaskModalOpen,
   setIsEditTaskModalOpen,
   setRerenderSignal,
+  setIsDraggingPossible,
 }) => {
   const [isDeleteTaskModalOpen, setIsDeleteModalOpen] = useState(false);
   const [deleteTaskModalMessage, setDeleteTaskModalMessage] = useState("");
   const [newTaskTitle, setNewTaskTitle] = useState(task.title);
   const [prevTaskTitle, setPrevTaskTitle] = useState(task.title);
 
+  const decodedNotes = task.notes.replace(/\|\|/g, "\n");
+  const [newTaskNotes, setNewTaskNotes] = useState(decodedNotes);
+  const [prevTaskNotes, setPrevTaskNotes] = useState(decodedNotes);
+
+  //handling task timestamps
+  const options: Intl.DateTimeFormatOptions = {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  };
+
+  const createdAtDate = new Date(task.createdAt);
+  const createdAt = createdAtDate.toLocaleDateString(undefined, options);
+
+  const updatedAtDate = new Date(task.updatedAt);
+  const updatedAt = updatedAtDate.toLocaleDateString(undefined, options);
+
+  //handling title changes
   const handleTitleOnChange = (
     event: React.ChangeEvent<HTMLInputElement>,
     taskId: string
@@ -68,6 +95,48 @@ const EditTask: React.FC<EditTaskProps> = ({
     }
   };
 
+  // handling notes changes
+  const handleNotesOnChange = (
+    event: React.ChangeEvent<HTMLTextAreaElement>,
+    taskId: string
+  ) => {
+    setNewTaskNotes(event.target.value);
+  };
+
+  const updateNotes = async (taskId: string, newNotes: string) => {
+    if (prevTaskNotes === newNotes) {
+      return;
+    }
+
+    //replacing new lines with special character before sending to backend
+    const formattedNotes = newNotes.trim().replace(/\n/g, "||");
+
+    try {
+      const response = await axios.post(
+        `http://localhost:5000/tasks/${taskId}/notes`,
+        {
+          newNotes: formattedNotes,
+        },
+        {
+          withCredentials: true,
+          headers: {
+            "Access-Control-Allow-Origin": "*",
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      if (response.status === 200) {
+        setPrevTaskNotes(newTaskNotes);
+        setRerenderSignal((prevSignal) => !prevSignal);
+      }
+    } catch (err: any) {
+      if (err.response && err.response.status === 404) {
+      } else {
+      }
+    }
+  };
+
+  //handling deleting task
   const deleteTask = (taskTitle: string) => {
     setDeleteTaskModalMessage(taskTitle);
     setIsDeleteModalOpen(true);
@@ -94,6 +163,7 @@ const EditTask: React.FC<EditTaskProps> = ({
     } catch (err: any) {}
   };
 
+  //closing edit task modal
   const closeEditTaskModal = (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>
   ) => {
@@ -101,6 +171,7 @@ const EditTask: React.FC<EditTaskProps> = ({
     if (event.target === event.currentTarget) {
       setIsEditTaskModalOpen(false);
       setNewTaskTitle(task.title);
+      setIsDraggingPossible(true);
     }
   };
 
@@ -110,52 +181,83 @@ const EditTask: React.FC<EditTaskProps> = ({
 
   return (
     isEditTaskModalOpen && (
-      <>
+      <div>
         <div
-          className="bg-black bg-opacity-30 fixed top-0 left-0 w-screen h-screen flex justify-center items-center z-20 cursor-default"
-          onMouseDown={closeEditTaskModal}
+          className="bg-black bg-opacity-30 fixed top-0 left-0 w-screen h-screen flex justify-center items-center z-30 cursor-default"
+          onMouseDown={(event) => {
+            closeEditTaskModal(event);
+            if (event.currentTarget === event.target) {
+              updateNotes(task._id, newTaskNotes);
+              setTaskTitle(newTaskTitle, task._id);
+            }
+          }}
         >
           <div
-            className="bg-white p-6 rounded-md cursor-default"
+            className="bg-white p-6 rounded-md cursor-default w-1/3 h-1/2"
             onClick={(event) => event.stopPropagation()}
           >
             <div>
-              <div className="flex justify-end">
-                <img
-                  src={process.env.PUBLIC_URL + "/icon-trash.svg"}
-                  alt="Trash Icon"
-                  onClick={() => {
-                    deleteTask(task.title);
-                  }}
-                  className="w-6 cursor-pointer"
-                />
+              <div className="grid grid-cols-2 font-400 text-xs text-gray-600">
+                <div>
+                  <p>
+                    <span>Created on {createdAt}</span>
+                  </p>
+                  <p>
+                    {task.createdAt !== task.updatedAt && (
+                      <span>Updated on {updatedAt}</span>
+                    )}
+                  </p>
+                </div>
+                <div className="flex justify-end">
+                  <img
+                    src={process.env.PUBLIC_URL + "/icon-trash.svg"}
+                    alt="Trash Icon"
+                    onClick={() => {
+                      deleteTask(task.title);
+                    }}
+                    className="w-6 cursor-pointer"
+                  />
+                </div>
               </div>
-              <p>Title</p>
-              <input
-                value={newTaskTitle}
-                maxLength={100}
-                onChange={(event) => handleTitleOnChange(event, task._id)}
-                onKeyDown={(
-                  event: React.KeyboardEvent<HTMLParagraphElement>
-                ) => {
-                  if (
-                    event.key === "Backspace" ||
-                    event.key === "Delete" ||
-                    event.key === "ArrowLeft" ||
-                    event.key === "ArrowRight"
-                  ) {
-                  } else if (
-                    event.currentTarget.textContent &&
-                    event.currentTarget.textContent.length > 60
-                  ) {
-                    event.preventDefault();
-                  } else if (event.key === "Enter" || event.key === "Escape") {
-                    event.currentTarget.blur();
-                  }
-                }}
-                onBlur={() => setTaskTitle(newTaskTitle, task._id)}
-                className="shadow appearance-none border border-gray-500 rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline"
-              ></input>
+              <div className="mt-4">
+                <p className="font-400">Title</p>
+                <input
+                  value={newTaskTitle}
+                  maxLength={100}
+                  onChange={(event) => handleTitleOnChange(event, task._id)}
+                  onKeyDown={(
+                    event: React.KeyboardEvent<HTMLParagraphElement>
+                  ) => {
+                    if (
+                      event.key === "Backspace" ||
+                      event.key === "Delete" ||
+                      event.key === "ArrowLeft" ||
+                      event.key === "ArrowRight"
+                    ) {
+                    } else if (
+                      event.currentTarget.textContent &&
+                      event.currentTarget.textContent.length > 60
+                    ) {
+                      event.preventDefault();
+                    } else if (
+                      event.key === "Enter" ||
+                      event.key === "Escape"
+                    ) {
+                      event.currentTarget.blur();
+                    }
+                  }}
+                  onBlur={() => setTaskTitle(newTaskTitle, task._id)}
+                  className="shadow appearance-none border border-gray-500 rounded w-full py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline"
+                ></input>
+                <p className="font-400 mt-4">Notes</p>
+                <textarea
+                  value={newTaskNotes}
+                  maxLength={500}
+                  onChange={(event) => handleNotesOnChange(event, task._id)}
+                  onBlur={() => updateNotes(task._id, newTaskNotes)}
+                  className="shadow appearance-none border border-gray-500 rounded w-full h-24 py-2 px-3 text-gray-700 mb-3 leading-tight focus:outline-none focus:shadow-outline resize-none"
+                ></textarea>
+              </div>
             </div>
           </div>
           {isDeleteTaskModalOpen && (
@@ -195,7 +297,7 @@ const EditTask: React.FC<EditTaskProps> = ({
             </div>
           )}
         </div>
-      </>
+      </div>
     )
   );
 };

--- a/frontend/todo_app/src/components/Set.tsx
+++ b/frontend/todo_app/src/components/Set.tsx
@@ -8,11 +8,14 @@ import AddTable from "./AddTable";
 import DeleteColumn from "./DeleteColumn";
 import EditTable from "./EditTable";
 
-interface Task {
+interface TaskData {
   _id: string;
   title: string;
   completed: boolean;
   column: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface User {
@@ -27,8 +30,8 @@ interface User {
 interface Column {
   _id: string;
   title: string;
-  pendingTasks: Task[];
-  completedTasks: Task[];
+  pendingTasks: TaskData[];
+  completedTasks: TaskData[];
   showCompletedTasks: boolean;
 }
 

--- a/frontend/todo_app/src/components/Task.tsx
+++ b/frontend/todo_app/src/components/Task.tsx
@@ -8,19 +8,30 @@ interface TaskData {
   title: string;
   completed: boolean;
   column: string;
+  notes: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface TaskProps {
   task: TaskData;
   taskIndex: Number;
   setRerenderSignal: React.Dispatch<React.SetStateAction<boolean>>;
+  isDraggingPossible: boolean;
+  setIsDraggingPossible: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-const Task: React.FC<TaskProps> = ({ task, taskIndex, setRerenderSignal }) => {
+const Task: React.FC<TaskProps> = ({
+  task,
+  taskIndex,
+  setRerenderSignal,
+  isDraggingPossible,
+  setIsDraggingPossible,
+}) => {
   const [isEditTaskModalOpen, setIsEditTaskModalOpen] = useState(false);
-
   const openEditTaskModal = () => {
     setIsEditTaskModalOpen(true);
+    setIsDraggingPossible(false);
   };
 
   const toggleTaskStatus = async (
@@ -29,7 +40,6 @@ const Task: React.FC<TaskProps> = ({ task, taskIndex, setRerenderSignal }) => {
     taskCompleted: boolean,
     taskColumn: string
   ) => {
-    console.log(taskColumn);
     try {
       const response = await axios.post(
         `http://localhost:5000/tasks/${taskId}/status`,
@@ -69,12 +79,15 @@ const Task: React.FC<TaskProps> = ({ task, taskIndex, setRerenderSignal }) => {
         />
         <div className="ml-2 min-w-1">{task.title}</div>
       </div>
-      <EditTask
-        task={task}
-        isEditTaskModalOpen={isEditTaskModalOpen}
-        setIsEditTaskModalOpen={setIsEditTaskModalOpen}
-        setRerenderSignal={setRerenderSignal}
-      />
+      {isEditTaskModalOpen && (
+        <EditTask
+          task={task}
+          isEditTaskModalOpen={isEditTaskModalOpen}
+          setIsEditTaskModalOpen={setIsEditTaskModalOpen}
+          setIsDraggingPossible={setIsDraggingPossible}
+          setRerenderSignal={setRerenderSignal}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This commit implements the notes field and timestamps data for tasks. In the notes text area, users can add new lines, which are encoded as '||' and decoded accordingly when received from the backend. 

Additionally, a bug that kept possible dragging and dropping tasks while the modal window was open has been fixed.